### PR TITLE
Cascade delete WMTS layer

### DIFF
--- a/geoservercloud/geoservercloud.py
+++ b/geoservercloud/geoservercloud.py
@@ -367,6 +367,9 @@ class GeoServerCloud:
     ) -> tuple[str, int]:
         return self.rest_service.publish_gwc_layer(workspace_name, layer, epsg)
 
+    def delete_gwc_layer(self, workspace_name: str, layer: str) -> tuple[str, int]:
+        return self.rest_service.delete_gwc_layer(workspace_name, layer)
+
     def get_styles(
         self, workspace_name: str | None = None
     ) -> tuple[list[str] | str, int]:

--- a/geoservercloud/services/restservice.py
+++ b/geoservercloud/services/restservice.py
@@ -167,6 +167,8 @@ class RestService:
                 resource_path,
                 params={"recurse": "true"},
             )
+            # Also delete the corresponding GWC layer (delete is not cascaded when using REST API)
+            self.delete_gwc_layer(workspace_name, published_layer)
         capabilities_url: str = (
             self.rest_client.get(
                 self.rest_endpoints.wmtsstore(workspace_name, wmts_store)
@@ -224,6 +226,12 @@ class RestService:
         response: Response = self.rest_client.put(
             self.gwc_endpoints.layer(workspace_name, layer),
             json=payload,
+        )
+        return response.content.decode(), response.status_code
+
+    def delete_gwc_layer(self, workspace_name: str, layer: str) -> tuple[str, int]:
+        response: Response = self.rest_client.delete(
+            self.gwc_endpoints.layer(workspace_name, layer)
         )
         return response.content.decode(), response.status_code
 

--- a/tests/test_cascaded_wmts.py
+++ b/tests/test_cascaded_wmts.py
@@ -166,6 +166,10 @@ def test_create_wmts_layer_already_exists(
             status=200,
             match=[responses.matchers.query_param_matcher({"recurse": "true"})],
         )
+        rsps.delete(
+            url=f"{geoserver.url}/gwc/rest/layers/{WORKSPACE}:{LAYER}.json",
+            status=200,
+        )
         rsps.get(
             f"{geoserver.url}/rest/workspaces/{WORKSPACE}/wmtsstores/{STORE}.json",
             status=200,

--- a/tests/test_gwc.py
+++ b/tests/test_gwc.py
@@ -85,6 +85,32 @@ def test_publish_gwc_layer_already_exists(geoserver: GeoServerCloud) -> None:
         assert code == 200
 
 
+def test_delete_gwc_layer(geoserver: GeoServerCloud) -> None:
+    with responses.RequestsMock() as rsps:
+        rsps.delete(
+            url=f"{geoserver.url}/gwc/rest/layers/{WORKSPACE}:{LAYER}.json",
+            status=200,
+            body=b"test_workspace:test_layer deleted",
+        )
+
+        content, code = geoserver.delete_gwc_layer(WORKSPACE, LAYER)
+        assert content == "test_workspace:test_layer deleted"
+        assert code == 200
+
+
+def test_delete_gwc_layer_not_found(geoserver: GeoServerCloud) -> None:
+    with responses.RequestsMock() as rsps:
+        rsps.delete(
+            url=f"{geoserver.url}/gwc/rest/layers/{WORKSPACE}:{LAYER}.json",
+            status=404,
+            body=b"Unknown layer: test_workspace:test_layer",
+        )
+
+        content, code = geoserver.delete_gwc_layer(WORKSPACE, LAYER)
+        assert content == "Unknown layer: test_workspace:test_layer"
+        assert code == 404
+
+
 def test_create_gridset(geoserver: GeoServerCloud) -> None:
     with responses.RequestsMock() as rsps:
         rsps.get(


### PR DESCRIPTION
The deletion of a GeoServer WMTS layer is not cascaded to the corresponding GWC layer when using the REST API so we have to do it explicitly