### PR TITLE
Use Timestamp as default datetime type

### DIFF
--- a/geoservercloud/utils.py
+++ b/geoservercloud/utils.py
@@ -43,7 +43,7 @@ def java_binding(data_type: str) -> str:
         case "float":
             return "java.lang.Float"
         case "datetime":
-            return "java.util.Date"
+            return "java.sql.Timestamp"
         case "Point":
             return "org.locationtech.jts.geom.Point"
         case "Line":


### PR DESCRIPTION
When creating a layer from an existing PG table that has a column with data type 'timestamp without time zone', GeoServer doesn't accept the Java binding 'java.util.Date' in the POST payload but instead expects 'java.sql.Timestamp'

Closes #54 