### PR TITLE
Deal with non-i18ned attribute values

### DIFF
--- a/geoservercloud/geoservercloud.py
+++ b/geoservercloud/geoservercloud.py
@@ -392,6 +392,16 @@ class GeoServerCloud:
         )
         return self.rest_service.create_feature_type(feature_type=feature_type)
 
+    def delete_feature_type(
+        self, workspace_name: str, datastore_name: str, layer_name: str
+    ) -> tuple[str, int]:
+        """
+        Delete a feature type and associated layer
+        """
+        return self.rest_service.delete_feature_type(
+            workspace_name, datastore_name, layer_name
+        )
+
     def create_layer_group(
         self,
         group: str,

--- a/geoservercloud/models/featuretype.py
+++ b/geoservercloud/models/featuretype.py
@@ -108,9 +108,9 @@ class FeatureType(EntityModel):
         feature_type = content["featureType"]
         workspace_name = feature_type["store"]["name"].split(":")[0]
         store_name = feature_type["store"]["name"].split(":")[1]
-        title = feature_type.get("title", feature_type.get("internationalTitle"))
+        title = feature_type.get("internationalTitle", feature_type.get("title"))
         abstract = feature_type.get(
-            "abstract", feature_type.get("internationalAbstract")
+            "internationalAbstract", feature_type.get("abstract")
         )
         if feature_type.get("metadataLinks"):
             metadata_links_payload = feature_type["metadataLinks"]["metadataLink"]
@@ -201,7 +201,13 @@ class FeatureType(EntityModel):
         return {"featureType": content}
 
     def put_payload(self) -> dict[str, Any]:
-        return self.post_payload()
+        content = self.post_payload()
+        # Force a null value on non-i18ned attributes, otherwise GeoServer sets it to the first i18n value
+        if content["featureType"].get("internationalTitle"):
+            content["featureType"]["title"] = None
+        if content["featureType"].get("internationalAbstract"):
+            content["featureType"]["abstract"] = None
+        return content
 
     def __repr__(self):
         return json.dumps(self.post_payload(), indent=4)

--- a/geoservercloud/services/restservice.py
+++ b/geoservercloud/services/restservice.py
@@ -288,6 +288,15 @@ class RestService:
             )
         return response.content.decode(), response.status_code
 
+    def delete_feature_type(
+        self, workspace_name: str, datastore_name: str, layer_name: str
+    ) -> tuple[str, int]:
+        response: Response = self.rest_client.delete(
+            self.rest_endpoints.featuretype(workspace_name, datastore_name, layer_name),
+            params={"recurse": "true"},
+        )
+        return response.content.decode(), response.status_code
+
     def create_layer_group(
         self,
         group: str,

--- a/tests/test_feature_type.py
+++ b/tests/test_feature_type.py
@@ -242,3 +242,19 @@ def test_update_feature_type(
 
         assert content == ""
         assert code == 200
+
+
+def test_delete_feature_type(geoserver: GeoServerCloud) -> None:
+    with responses.RequestsMock() as rsps:
+        rsps.delete(
+            f"{geoserver.url}/rest/workspaces/{WORKSPACE}/datastores/{STORE}/featuretypes/{LAYER}.json",
+            status=200,
+            body=b"",
+            match=[responses.matchers.query_param_matcher({"recurse": "true"})],
+        )
+        content, code = geoserver.delete_feature_type(
+            workspace_name=WORKSPACE, datastore_name=STORE, layer_name=LAYER
+        )
+
+        assert content == ""
+        assert code == 200

--- a/tests/test_feature_type.py
+++ b/tests/test_feature_type.py
@@ -147,6 +147,16 @@ def feature_type_post_payload(
     return {"featureType": content}
 
 
+@pytest.fixture(scope="module")
+def feature_type_put_payload(
+    feature_type_post_payload: dict[str, dict[str, Any]]
+) -> dict[str, dict[str, Any]]:
+    content = feature_type_post_payload.copy()
+    content["featureType"]["title"] = None
+    content["featureType"]["abstract"] = None
+    return content
+
+
 def test_get_feature_types(
     geoserver: GeoServerCloud, feature_types_get_response_payload: dict[str, Any]
 ) -> None:
@@ -218,7 +228,7 @@ def test_create_feature_type(
 
 
 def test_update_feature_type(
-    geoserver: GeoServerCloud, feature_type_post_payload: dict[str, dict[str, Any]]
+    geoserver: GeoServerCloud, feature_type_put_payload: dict[str, dict[str, Any]]
 ) -> None:
     with responses.RequestsMock() as rsps:
         rsps.get(
@@ -227,7 +237,7 @@ def test_update_feature_type(
         )
         rsps.put(
             f"{geoserver.url}/rest/workspaces/{WORKSPACE}/datastores/{STORE}/featuretypes/{LAYER}.json",
-            match=[responses.matchers.json_params_matcher(feature_type_post_payload)],
+            match=[responses.matchers.json_params_matcher(feature_type_put_payload)],
             status=200,
             body=b"",
         )


### PR DESCRIPTION
1. Deal with non-i18ned attribute values
    
Optional i18ned attributes such as 'title' and 'internationalTitle' are in fact not mutually exclusive. GeoServer goes as far as setting 'title' to the first of the i18n values on PUT request if 'title' is not specified but 'internationalTitle' is. 
Here we set precedence on the i18n attribute if it is present in the GET response payload and we force a null value on the non-i18ned attribute in the PUT payload to avoid unwanted side effects.

2.  Add delete feature type method

Closes #57 
